### PR TITLE
security: CWE-943: Fix GraphQL injection in CreateCP-KS.ps1 — VC-53689

### DIFF
--- a/CloudProviders/CreateCP-KS.ps1
+++ b/CloudProviders/CreateCP-KS.ps1
@@ -91,20 +91,36 @@ function CheckIfCPExists([string] $cloudProviderName) {
 }
 
 function CreateCloudProviderMutation ([string] $cloudProviderName, [string] $teamId, [string] $authorizedTeamId, [string] $cloudProviderType, [string] $awsRole, [string] $awsAccountId) {
-   
 
-    if (-not [string]::IsNullOrEmpty($authorizedTeamId)) {
-        $authTeams = "`"$authorizedTeamId`""
+    # Validate UUID format for teamId
+    $uuidPattern = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    if ($teamId -notmatch $uuidPattern) {
+        Write-Host "Invalid teamId format: '$teamId'. Must be a valid UUID."
+        return
     }
-    # GraphQL mutation with dynamic parameters
-    $mutation = @"
-mutation Mutation {
+
+    # Validate cloudProviderType against allowlist
+    $validTypes = @('AWS', 'AZURE', 'GCP')
+    if ($cloudProviderType -notin $validTypes) {
+        Write-Host "Invalid cloudProviderType: '$cloudProviderType'. Must be one of: $($validTypes -join ', ')"
+        return
+    }
+
+    # Build authorizedTeams array for variables
+    $authTeamsArray = @()
+    if (-not [string]::IsNullOrEmpty($authorizedTeamId)) {
+        $authTeamsArray = @($authorizedTeamId)
+    }
+
+    # GraphQL mutation with variables (literal here-string)
+    $mutation = @'
+mutation Mutation($cloudProviderName: String!, $teamId: ID!, $authorizedTeams: [ID!], $cloudProviderType: CloudProviderType!, $awsRole: String!, $awsAccountId: String!) {
   createCloudProvider(
     input: {
-      authorizedTeams: [$authTeams]
-      awsConfiguration: { role: "$awsRole", accountId: "$awsAccountId" }
-      name: "$cloudProviderName"
-      teamId: "$teamId"
+      authorizedTeams: $authorizedTeams
+      awsConfiguration: { role: $awsRole, accountId: $awsAccountId }
+      name: $cloudProviderName
+      teamId: $teamId
       type: $cloudProviderType
     }
   ) {
@@ -112,12 +128,20 @@ mutation Mutation {
     id
   }
 }
-"@
+'@
 
-    # Create the GraphQL request body
+    # Create the GraphQL request body with variables
     $body = @{
         query = $mutation
-    } | ConvertTo-Json
+        variables = @{
+            cloudProviderName = $cloudProviderName
+            teamId = $teamId
+            authorizedTeams = $authTeamsArray
+            cloudProviderType = $cloudProviderType
+            awsRole = $awsRole
+            awsAccountId = $awsAccountId
+        }
+    } | ConvertTo-Json -Depth 10
 
     # Make the GraphQL API call
     try {
@@ -135,21 +159,35 @@ mutation Mutation {
 
 function CreateCloudKeystoreForACM([string] $cloudKeystoreName, [string] $teamId, [string] $authorizedTeamId, [string] $cloudProviderId, [string[]] $acmRegions) {
 
+    # Validate UUID format for teamId and cloudProviderId
+    $uuidPattern = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    if ($teamId -notmatch $uuidPattern) {
+        Write-Host "Invalid teamId format: '$teamId'. Must be a valid UUID."
+        return
+    }
+    if ($cloudProviderId -notmatch $uuidPattern) {
+        Write-Host "Invalid cloudProviderId format: '$cloudProviderId'. Must be a valid UUID."
+        return
+    }
+
+    # Build authorizedTeams array for variables
+    $authTeamsArray = @()
     if (-not [string]::IsNullOrEmpty($authorizedTeamId)) {
-        $authTeams = "`"$authorizedTeamId`""
+        $authTeamsArray = @($authorizedTeamId)
     }
 
     foreach ($region in $acmRegions) {
-    
-        $mutation = @"
-    mutation CreateCloudKeystore {
+
+        # GraphQL mutation with variables (literal here-string)
+        $mutation = @'
+    mutation CreateCloudKeystore($name: String!, $teamId: ID!, $cloudProviderId: ID!, $region: String!, $authorizedTeams: [ID!]) {
         createCloudKeystore(
           input: {
-            name: "$cloudKeystoreName-$region"
-            teamId: "$teamId"
-            cloudProviderId: "$cloudProviderId"
-            acmConfiguration: { region: "$region" }
-            authorizedTeams: [$authTeams]
+            name: $name
+            teamId: $teamId
+            cloudProviderId: $cloudProviderId
+            acmConfiguration: { region: $region }
+            authorizedTeams: $authorizedTeams
             type: ACM
           }
         ) {
@@ -157,11 +195,18 @@ function CreateCloudKeystoreForACM([string] $cloudKeystoreName, [string] $teamId
           name
         }
     }
-"@
-        # Create the GraphQL request body
+'@
+        # Create the GraphQL request body with variables
         $body = @{
             query = $mutation
-        } | ConvertTo-Json
+            variables = @{
+                name = "$cloudKeystoreName-$region"
+                teamId = $teamId
+                cloudProviderId = $cloudProviderId
+                region = $region
+                authorizedTeams = $authTeamsArray
+            }
+        } | ConvertTo-Json -Depth 10
 
         # Make the GraphQL API call
         try {


### PR DESCRIPTION
## Summary

Fixes GraphQL injection vulnerability in `CloudProviders/CreateCP-KS.ps1` by replacing string interpolation with GraphQL variables and adding input validation.

## Finding

**CWE-943**: Improper Neutralization of Special Elements in Data Query Logic

CSV-derived fields were directly interpolated into GraphQL mutation documents via PowerShell expandable here-strings without escaping, allowing CSV authors to inject arbitrary GraphQL syntax. The `cloudProviderType` field was embedded as an unquoted enum token, enabling injection without quote-escaping.

CVSS: 5.1 (CVSS:4.0/AV:L/AC:L/AT:P/PR:N/UI:A/VC:N/VI:N/VA:N/SC:L/SI:H/SA:L)

## Remediation

1. **Replaced expandable here-strings with literal here-strings** in `CreateCloudProviderMutation` and `CreateCloudKeystoreForACM`
2. **Implemented GraphQL variables** to properly parameterize all CSV-derived values (`cloudProviderName`, `teamId`, `cloudProviderType`, `awsRole`, `awsAccountId`, `cloudProviderId`, `region`)
3. **Added allowlist validation** for `cloudProviderType` against `@('AWS', 'AZURE', 'GCP')`
4. **Added UUID regex validation** for `teamId` and `cloudProviderId` fields
5. **Converted `authorizedTeams`** to proper array variables instead of string concatenation

All user-controlled input is now passed through GraphQL's variable mechanism, which provides automatic escaping and type safety.

## Verification

- Code review: Verified expandable here-strings converted to literal strings with proper variable substitution
- Input validation: UUID pattern enforced for ID fields, enum allowlist enforced for CloudProviderType
- No build or test regression (PowerShell script repository)