### PR TITLE
security: CWE-214: API key exposure via command-line arguments — VC-53687

### DIFF
--- a/CloudProviders/CreateCP-KS.ps1
+++ b/CloudProviders/CreateCP-KS.ps1
@@ -36,19 +36,28 @@
      A variable that stores the path to the .csv file that contains the Cloud Provider and Cloud Keysore data.
 .NOTES
     Executin example
-    ./CreateCP-KS.ps1 -ApiUrl "https://api.venafi.cloud/graphql" -TPPLApiKey "3c9e4ca1-7b6c-4c2c-8bec-f955b6fc5a9c" -CsvPath "./data.csv"
+    WARNING: Do not pass the API key on the command line. Use the TPPL_API_KEY environment variable.
+    $env:TPPL_API_KEY = "3c9e4ca1-7b6c-4c2c-8bec-f955b6fc5a9c"; ./CreateCP-KS.ps1 -ApiUrl "https://api.venafi.cloud/graphql" -CsvPath "./data.csv"
     Multivalue parameters in the CSV are separated by ';'
 ##################################################################################################>
 
 param(
     [string]$ApiUrl,
-    [string]$TPPLApiKey,
     [string]$CsvPath
 )
 
+# SECURITY (CWE-214): The tenant API key MUST be supplied via the TPPL_API_KEY
+# environment variable, not on the command line. argv is visible to other local
+# users (process listing), persisted to PSReadLine history, and captured in CI logs.
+$TPPLApiKey = $env:TPPL_API_KEY
+
 # Check if required parameters are provided
-if (-not $ApiUrl -or -not $TPPLApiKey -or -not $CsvPath) {
-    Write-Host "Please provide: -ApiUrl <Api_Url> -TPPLApiKey <API_KEY> -CsvPath <CSV_Path>"
+if (-not $ApiUrl -or -not $CsvPath) {
+    Write-Host "Please provide: -ApiUrl <Api_Url> -CsvPath <CSV_Path>"
+    exit 1
+}
+if (-not $TPPLApiKey) {
+    Write-Host "TPPL_API_KEY environment variable is not set. Set it before running this script (do not pass the API key on the command line)."
     exit 1
 }
 

--- a/CloudProviders/README.md
+++ b/CloudProviders/README.md
@@ -19,12 +19,14 @@ None
 
 ## Usage
 
-1. Update the script with your API URL and API key.
+1. Set the TPPL_API_KEY environment variable with your Venafi API key (do not pass it on the command line).
 2. Prepare a CSV file with the required configuration data (see CSV format below).
 3. Run the script with the following parameters:
 
    ```powershell
-   ./CreateCP-KS.ps1 -ApiUrl "https://api.venafi.cloud/graphql" -TPPLApiKey "your_api_key" -CsvPath "path/to/your/data.csv"
+   $env:TPPL_API_KEY = "your_api_key"
+   ./CreateCP-KS.ps1 -ApiUrl "https://api.venafi.cloud/graphql" -CsvPath "path/to/your/data.csv"
+   ```
 so there would not be mistakes with the API URL
    
 


### PR DESCRIPTION
## Summary

Fix CWE-214 (Invocation of Process Using Visible Sensitive Information) in CloudProviders/CreateCP-KS.ps1 by removing the `-TPPLApiKey` command-line parameter and reading the API key from the `TPPL_API_KEY` environment variable instead.

## Finding

The PowerShell script accepted the Venafi tenant API key as a plain-string command-line argument (`-TPPLApiKey`), and the documentation instructed users to pass it literally on argv. This exposed the key via:
- OS process listing (`ps -ef`, `/proc/*/cmdline`, `Get-CimInstance Win32_Process`)
- PSReadLine shell history (`ConsoleHost_history.txt`)
- CI job logs

Any principal able to read those channels could obtain the key, which grants full read/write/delete access to the Venafi TLS Protect Cloud tenant.

**CVSS**: 5.6 (CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:N/VA:N/SC:H/SI:H/SA:H)

## Remediation

1. **Removed `-TPPLApiKey` from param()**: The script no longer accepts the API key as a command-line argument.
2. **Read from environment variable**: Added `$TPPLApiKey = $env:TPPL_API_KEY` to read the key from the environment instead.
3. **Updated validation**: Split the parameter check to validate the API key separately with a clear error message instructing users to set the environment variable.
4. **Updated documentation**: Modified both the in-script `.NOTES` example and `CloudProviders/README.md` to demonstrate the secure invocation pattern using the environment variable, with explicit warnings against passing the key on the command line.

This approach matches the secure pattern already used in the sibling Python recipe (`CertificateSearch-Paging/certsearchPaging.py`).

## Verification

- **Process listing**: The documented invocation no longer includes `-TPPLApiKey`, so `ps` output shows only `-ApiUrl ... -CsvPath ...`
- **Shell history**: The script invocation line contains no key; only the env-var assignment (if typed interactively) would be logged
- **CI logs**: The invocation line logged by runners no longer carries the key
- **Backward compatibility**: Breaking change by design — existing automation passing `-TPPLApiKey` will fail with a clear PowerShell parameter-binding error, forcing operators to adopt the secure pattern